### PR TITLE
Improve random string generator

### DIFF
--- a/src/generators.ts
+++ b/src/generators.ts
@@ -25,7 +25,7 @@ type Map<T> = {
 export function mockPrimitive(type: ApiBuilderPrimitiveType): any {
   switch (type.fullName) {
     case Kind.STRING:
-      return faker.lorem.word();
+      return faker.random.word();
     case Kind.BOOLEAN:
       return faker.random.boolean();
     case Kind.DATE_ISO8601:


### PR DESCRIPTION
For random strings switch from `faker.lorem.word()` to `faker.random.word()` as the latter has a much larger pool of random tokens, this should help improve conflicts when generating `id` fields in models until a better solution can be found.