### PR TITLE
Use faker.random.alphaNumeric for random strings

### DIFF
--- a/src/generators.ts
+++ b/src/generators.ts
@@ -25,7 +25,7 @@ type Map<T> = {
 export function mockPrimitive(type: ApiBuilderPrimitiveType): any {
   switch (type.fullName) {
     case Kind.STRING:
-      return faker.random.word();
+      return faker.random.alphaNumeric(16);
     case Kind.BOOLEAN:
       return faker.random.boolean();
     case Kind.DATE_ISO8601:


### PR DESCRIPTION
Previously use of `faker.random.word` produced strings with spaces which had unexpected side-effects. I think it's better to ensure the string is one 'word'.